### PR TITLE
Delete Cloud Kit Records and completion blocks

### DIFF
--- a/IceCream/Classes/DatabaseManagerProtocol.swift
+++ b/IceCream/Classes/DatabaseManagerProtocol.swift
@@ -45,9 +45,9 @@ extension DatabaseManager {
     
     func prepare() {
         syncObjects.forEach {
-            $0.pipeToEngine = { [weak self] recordsToStore, recordIDsToDelete in
+            $0.pipeToEngine = { [weak self] recordsToStore, recordIDsToDelete, completion in
                 guard let self = self else { return }
-                self.syncRecordsToCloudKit(recordsToStore: recordsToStore, recordIDsToDelete: recordIDsToDelete)
+                self.syncRecordsToCloudKit(recordsToStore: recordsToStore, recordIDsToDelete: recordIDsToDelete, completion: completion)
             }
         }
     }

--- a/IceCream/Classes/Syncable.swift
+++ b/IceCream/Classes/Syncable.swift
@@ -31,8 +31,13 @@ public protocol Syncable: AnyObject {
     
     /// CloudKit related
     func pushLocalObjectsToCloudKit()
+    func deleteCloudKitRecords(completion: @escaping ((Error?) -> ()))
     
     /// Callback
-    var pipeToEngine: ((_ recordsToStore: [CKRecord], _ recordIDsToDelete: [CKRecord.ID]) -> ())? { get set }
+    var pipeToEngine: ((_ recordsToStore: [CKRecord],
+                       _ recordIDsToDelete: [CKRecord.ID],
+                       _ completion: ((Error?) -> ())?)
+                               -> ())? { get set }
+    
     
 }


### PR DESCRIPTION

Delete cloudkit records
-- added a method that takes all the existing local realm records and deletes them from cloudkit

the pipeToEngine block sync records to CloudKit. 
-- added a completion block to the block signature so our client callers can tell when the operation completes or if it has an error. 