### PR TITLE
Delete Cloud Records and Completion Blocks

### DIFF
--- a/Example/IceCream_Example.xcodeproj/project.pbxproj
+++ b/Example/IceCream_Example.xcodeproj/project.pbxproj
@@ -358,11 +358,13 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = IceCream_Example/IceCream_Example.entitlements;
 				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = EQRQCAG846;
 				INFOPLIST_FILE = IceCream_Example/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.pixite.IceCream-Example";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -376,11 +378,13 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = IceCream_Example/IceCream_Example.entitlements;
 				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = EQRQCAG846;
 				INFOPLIST_FILE = IceCream_Example/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.pixite.IceCream-Example";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/Example/IceCream_Example/IceCream_Example.entitlements
+++ b/Example/IceCream_Example/IceCream_Example.entitlements
@@ -6,7 +6,7 @@
 	<string>development</string>
 	<key>com.apple.developer.icloud-container-identifiers</key>
 	<array>
-		<string>iCloud.$(CFBundleIdentifier)</string>
+		<string>iCloud.com.pixite.IceCream-Example</string>
 	</array>
 	<key>com.apple.developer.icloud-services</key>
 	<array>

--- a/IceCream/Classes/DatabaseManagerProtocol.swift
+++ b/IceCream/Classes/DatabaseManagerProtocol.swift
@@ -45,9 +45,9 @@ extension DatabaseManager {
     
     func prepare() {
         syncObjects.forEach {
-            $0.pipeToEngine = { [weak self] recordsToStore, recordIDsToDelete in
+            $0.pipeToEngine = { [weak self] recordsToStore, recordIDsToDelete, completion in
                 guard let self = self else { return }
-                self.syncRecordsToCloudKit(recordsToStore: recordsToStore, recordIDsToDelete: recordIDsToDelete)
+                self.syncRecordsToCloudKit(recordsToStore: recordsToStore, recordIDsToDelete: recordIDsToDelete, completion: completion)
             }
         }
     }

--- a/IceCream/Classes/PrivateDatabaseManager.swift
+++ b/IceCream/Classes/PrivateDatabaseManager.swift
@@ -79,7 +79,7 @@ final class PrivateDatabaseManager: DatabaseManager {
                     // As we register local database in the first step, we have to force push local objects which
                     // have not been caught to CloudKit to make data in sync
                     DispatchQueue.main.async {
-                        object.pushLocalObjectsToCloudKit()
+                        object.pushLocalObjectsToCloudKit(completion: nil)
                     }
                 }
             case .retry(let timeToWait, _):

--- a/IceCream/Classes/SyncEngine.swift
+++ b/IceCream/Classes/SyncEngine.swift
@@ -79,8 +79,8 @@ extension SyncEngine {
     
     /// Push all existing local data to CloudKit
     /// You should NOT to call this method too frequently
-    public func pushAll() {
-        databaseManager.syncObjects.forEach { $0.pushLocalObjectsToCloudKit() }
+    public func pushAll(completionHandler: ((Error?) -> Void)? = nil) {
+        databaseManager.syncObjects.forEach { $0.pushLocalObjectsToCloudKit(completion: completionHandler) }
     }
     
 }

--- a/IceCream/Classes/SyncEngine.swift
+++ b/IceCream/Classes/SyncEngine.swift
@@ -79,8 +79,8 @@ extension SyncEngine {
     
     /// Push all existing local data to CloudKit
     /// You should NOT to call this method too frequently
-    public func pushAll(completionHandler: ((Error?) -> Void)? = nil) {
-        databaseManager.syncObjects.forEach { $0.pushLocalObjectsToCloudKit(completion: completionHandler) }
+    public func pushAll() {
+        databaseManager.syncObjects.forEach { $0.pushLocalObjectsToCloudKit(completion: nil) }
     }
     
 }

--- a/IceCream/Classes/SyncObject.swift
+++ b/IceCream/Classes/SyncObject.swift
@@ -178,13 +178,13 @@ extension SyncObject: Syncable {
         }
     }
     
-    public func deleteCloudKitRecords(completion: ((Error?) -> ())?) {
+    public func deleteCloudKitRecords(completion: ((Error?) -> ())? = nil) {
         let realm = try! Realm(configuration: self.realmConfiguration)
         let recordsIDsToDelete: [CKRecord.ID] = realm.objects(T.self).filter { !$0.isDeleted }.map { $0.recordID }
         pipeToEngine?([], recordsIDsToDelete, completion)
     }
     
-    public func pushLocalObjectsToCloudKit(completion: ((Error?) -> ())?) {
+    public func pushLocalObjectsToCloudKit(completion: ((Error?) -> ())? = nil) {
         let realm = try! Realm(configuration: self.realmConfiguration)
         let recordsToStore: [CKRecord] = realm.objects(T.self).filter { !$0.isDeleted }.map { $0.record }
         pipeToEngine?(recordsToStore, [], completion)

--- a/IceCream/Classes/SyncObject.swift
+++ b/IceCream/Classes/SyncObject.swift
@@ -84,6 +84,7 @@ extension SyncObject: Syncable {
     }
     
     public func add(record: CKRecord) {
+        print("^^ SyncObject add record : \(record)")
         BackgroundWorker.shared.start {
             let realm = try! Realm(configuration: self.realmConfiguration)
             guard let object = T.parseFromRecord(
@@ -114,6 +115,7 @@ extension SyncObject: Syncable {
     }
     
     public func delete(recordID: CKRecord.ID) {
+        print("^^ SyncObject delete record ID: \(recordID)")
         BackgroundWorker.shared.start {
             let realm = try! Realm(configuration: self.realmConfiguration)
             guard let object = realm.object(ofType: T.self, forPrimaryKey: T.primaryKeyForRecordID(recordID: recordID)) else {

--- a/IceCream/Classes/SyncObject.swift
+++ b/IceCream/Classes/SyncObject.swift
@@ -178,16 +178,16 @@ extension SyncObject: Syncable {
         }
     }
     
-    public func deleteCloudKitRecords(completion: @escaping ((Error?) -> ())) {
+    public func deleteCloudKitRecords(completion: ((Error?) -> ())?) {
         let realm = try! Realm(configuration: self.realmConfiguration)
         let recordsIDsToDelete: [CKRecord.ID] = realm.objects(T.self).filter { !$0.isDeleted }.map { $0.recordID }
         pipeToEngine?([], recordsIDsToDelete, completion)
     }
     
-    public func pushLocalObjectsToCloudKit() {
+    public func pushLocalObjectsToCloudKit(completion: ((Error?) -> ())?) {
         let realm = try! Realm(configuration: self.realmConfiguration)
         let recordsToStore: [CKRecord] = realm.objects(T.self).filter { !$0.isDeleted }.map { $0.record }
-        pipeToEngine?(recordsToStore, [], nil)
+        pipeToEngine?(recordsToStore, [], completion)
     }
     
 }

--- a/IceCream/Classes/Syncable.swift
+++ b/IceCream/Classes/Syncable.swift
@@ -31,8 +31,13 @@ public protocol Syncable: AnyObject {
     
     /// CloudKit related
     func pushLocalObjectsToCloudKit()
+    func deleteCloudKitRecords(completion: @escaping ((Error?) -> ()))
     
     /// Callback
-    var pipeToEngine: ((_ recordsToStore: [CKRecord], _ recordIDsToDelete: [CKRecord.ID]) -> ())? { get set }
+    var pipeToEngine: ((_ recordsToStore: [CKRecord],
+                       _ recordIDsToDelete: [CKRecord.ID],
+                       _ completion: ((Error?) -> ())?)
+                               -> ())? { get set }
+    
     
 }

--- a/IceCream/Classes/Syncable.swift
+++ b/IceCream/Classes/Syncable.swift
@@ -30,8 +30,8 @@ public protocol Syncable: AnyObject {
     func resolvePendingRelationships()
     
     /// CloudKit related
-    func pushLocalObjectsToCloudKit()
-    func deleteCloudKitRecords(completion: @escaping ((Error?) -> ()))
+    func pushLocalObjectsToCloudKit(completion: ((Error?) -> ())?)
+    func deleteCloudKitRecords(completion: ((Error?) -> ())?)
     
     /// Callback
     var pipeToEngine: ((_ recordsToStore: [CKRecord],

--- a/IceCream/Classes/Syncable.swift
+++ b/IceCream/Classes/Syncable.swift
@@ -39,5 +39,4 @@ public protocol Syncable: AnyObject {
                        _ completion: ((Error?) -> ())?)
                                -> ())? { get set }
     
-    
 }


### PR DESCRIPTION

Delete cloudkit records
-- added a method that takes all the existing local realm records and deletes them from cloudkit

Completion Blocks.
-- added completion blocks to various methods/blocks so our client callers can tell when the operation completes or if it has an error.

Update dev team and bundle project values so example can build.
