### PR TITLE
Improve Fetch Error handling

### DIFF
--- a/IceCream/Classes/PrivateDatabaseManager.swift
+++ b/IceCream/Classes/PrivateDatabaseManager.swift
@@ -260,24 +260,3 @@ extension PrivateDatabaseManager {
     }
 }
 
-extension ErrorHandler.CKOperationResultType {
-    // these should be all the cases where we will retry an operation.
-    // currently, they are:
-    // 1. cloudkit tells us we can retry after a period of time
-    // 2. change token expired -- retry after resetting token
-    func canRetry() -> Bool {
-        switch self {
-            case .retry(_, _):
-                return true
-            case .recoverableError(let reason, _):
-                if case .changeTokenExpired = reason {
-                    return true
-                } else {
-                    // other errors are recoverable but the user needs to take action
-                    return false
-                }
-            default:
-                return false
-        }
-    }
-}


### PR DESCRIPTION
improves error handling when fetching db changes and zone changes
- handle cases where there was an error but callback was not executed
- handle zone fetch issue where callback was executed with initial error and then executed again after a retry.  this blows up if the client is using async and continuations as it'll expect the completion to be executed exactly once.

this is being used in the Pigment PR:
https://github.com/pixiteapps/Pigment/pull/1366
