### PR TITLE
Fix Hanging Initialization

### DIFF
--- a/IceCream/Classes/PrivateDatabaseManager.swift
+++ b/IceCream/Classes/PrivateDatabaseManager.swift
@@ -62,6 +62,8 @@ final class PrivateDatabaseManager: DatabaseManager {
             }
         }
         
+        // upping service quality will trigger better error reporting e.g. internet disconnected will return error instead of just hanging...
+        changesOperation.qualityOfService = .userInitiated
         database.add(changesOperation)
     }
     


### PR DESCRIPTION
we added initialFetchCompletions so we expect something to return -- either record updates or an error.
using the default quality of service, operations may just hang if there is an error.

up the fetch db changes operation quality of service so that it returns an error instead of never returning when errors occur
e.g. internet disconnected
https://stackoverflow.com/questions/36230005/ckqueryoperation-not-returning-error-when-device-offline

- handle some edge account status errors