### PR TITLE
Throttle notifications

### DIFF
--- a/Example/IceCream_Example.xcodeproj/project.pbxproj
+++ b/Example/IceCream_Example.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 52;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -289,7 +289,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.2;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -342,7 +342,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.2;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SWIFT_COMPILATION_MODE = wholemodule;
@@ -360,6 +360,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = EQRQCAG846;
 				INFOPLIST_FILE = IceCream_Example/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -380,6 +381,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = EQRQCAG846;
 				INFOPLIST_FILE = IceCream_Example/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/IceCream.podspec
+++ b/IceCream.podspec
@@ -20,7 +20,7 @@ Pod::Spec.new do |s|
 
   s.social_media_url = 'https://twitter.com/caiyue5'
 
-  s.ios.deployment_target = '15.0'
+  s.ios.deployment_target = '14.0'
   s.osx.deployment_target = '10.12'
   s.tvos.deployment_target = '10.0'
   s.watchos.deployment_target = '3.0'

--- a/IceCream.podspec
+++ b/IceCream.podspec
@@ -20,7 +20,7 @@ Pod::Spec.new do |s|
 
   s.social_media_url = 'https://twitter.com/caiyue5'
 
-  s.ios.deployment_target = '11.0'
+  s.ios.deployment_target = '15.0'
   s.osx.deployment_target = '10.12'
   s.tvos.deployment_target = '10.0'
   s.watchos.deployment_target = '3.0'

--- a/IceCream/Classes/PrivateDatabaseManager.swift
+++ b/IceCream/Classes/PrivateDatabaseManager.swift
@@ -297,7 +297,7 @@ extension PrivateDatabaseManager {
 
         fetchNotificationCancellable = NotificationCenter.default
             .publisher(for: Notifications.cloudKitDataDidChangeRemotely.name)
-            .throttle(for: 5.0, scheduler: DispatchQueue.global(qos: .utility), latest: true)
+            .throttle(for: 2.0, scheduler: DispatchQueue.global(qos: .utility), latest: true)
             .sink() { [weak self] _ in
                 self?.fetchChangesInDatabase(nil)
             }

--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 let package = Package(
     name: "IceCream",
     platforms: [
-        .macOS(.v10_12), .iOS(.v15), .tvOS(.v10), .watchOS(.v3)
+        .macOS(.v10_12), .iOS(.v14), .tvOS(.v10), .watchOS(.v3)
     ],
     products: [
         .library(

--- a/Package.swift
+++ b/Package.swift
@@ -1,10 +1,10 @@
-// swift-tools-version:5.1
+// swift-tools-version:5.5
 import PackageDescription
 
 let package = Package(
     name: "IceCream",
     platforms: [
-        .macOS(.v10_12), .iOS(.v11), .tvOS(.v10), .watchOS(.v3)
+        .macOS(.v10_12), .iOS(.v15), .tvOS(.v10), .watchOS(.v3)
     ],
     products: [
         .library(
@@ -20,7 +20,11 @@ let package = Package(
     targets: [
         .target(
             name: "IceCream",
-            dependencies: ["RealmSwift", "Realm"],
+            dependencies: [
+                .product(name: "RealmSwift", package: "realm-swift"),
+                .product(name: "Realm", package: "realm-swift")
+                
+            ],
             path: "IceCream",
             sources: ["Classes"])
     ],


### PR DESCRIPTION
this PR is mainly to add throttling of cloudkit notifications that trigger cloudkit fetches.
- i've seen multiple notifications that come in quickly and multiple concurrent fetches isn't necessary and not good for performance. 
- also it's suspected that multiple concurrent fetches may cause crashes.   

Changes are:
- bump deployment targets to ios 14/15 for pod and example app
- add debug logging for fetching zone changes and which change ops are running
- change to use recordWasChangedBlock as recordChangeBlock was deprecated
	- (there are actually several deprecations that need fixing -- let's save that for later)
- throttle notification handling to reduce concurrent fetches

Pigment PR that uses this code:
https://github.com/pixiteapps/Pigment/pull/1474